### PR TITLE
Fix report button not showing up

### DIFF
--- a/src/twitch_content.css
+++ b/src/twitch_content.css
@@ -8,8 +8,8 @@
 
 .nor-report-btn {
     position: absolute;
-    top: 0.3rem;
-    right: 0.3rem;
+    top: -0.7rem;
+    right: 4.3rem;
     z-index: 100;
     border-radius: 0.1em;
     padding: 0.2em 0.4em;

--- a/src/twitch_content.js
+++ b/src/twitch_content.js
@@ -4,9 +4,9 @@ const REPORT_BOT_NAME = 'norreportbot';
 const REPORT_BOT_ID = '500840578';
 
 
-function getInternalInstance(elem) {
+function getFiber(elem) {
     for (const key in elem)
-        if (key.startsWith('__reactInternalInstance$'))
+        if (key.startsWith('__reactFiber$'))
             return elem[key];
 }
 
@@ -31,7 +31,7 @@ function findInstance(instance, predicate) {
 
 function getMessage(elem) {
     const instance = findInstance(
-        getInternalInstance(elem),
+        getFiber(elem),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.message);
 
     return instance && instance.stateNode.props.message;
@@ -39,7 +39,7 @@ function getMessage(elem) {
 
 function getWhisperThread(elem) {
     const instance = findInstance(
-        getInternalInstance(elem),
+        getFiber(elem),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.threadID);
 
     return instance && instance.stateNode.props;
@@ -47,7 +47,7 @@ function getWhisperThread(elem) {
 
 function getChat() {
     const instance = findInstance(
-        getInternalInstance(document.querySelector('.chat-room')),
+        getFiber(document.querySelector('.chat-room')),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.onSendMessage);
 
     return instance && instance.stateNode.props;

--- a/src/twitch_content.js
+++ b/src/twitch_content.js
@@ -10,10 +10,10 @@ function getFiber(elem) {
             return elem[key];
 }
 
-function findInstance(instance, predicate) {
-    // Recurse through the parents of an instance until one matching the predicate is found
+function findFiber(fiber, predicate) {
+    // Recurse through the parents of a fiber until one matching the predicate is found
 
-    let cur = instance,
+    let cur = fiber,
         depth = 0;
 
     while (cur && !predicate(cur)) {
@@ -30,27 +30,27 @@ function findInstance(instance, predicate) {
 // Twitch helpers
 
 function getMessage(elem) {
-    const instance = findInstance(
+    const fiber = findFiber(
         getFiber(elem),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.message);
 
-    return instance && instance.stateNode.props.message;
+    return fiber && fiber.stateNode.props.message;
 }
 
 function getWhisperThread(elem) {
-    const instance = findInstance(
+    const fiber = findFiber(
         getFiber(elem),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.threadID);
 
-    return instance && instance.stateNode.props;
+    return fiber && fiber.stateNode.props;
 }
 
 function getChat() {
-    const instance = findInstance(
+    const fiber = findFiber(
         getFiber(document.querySelector('.chat-room')),
         i => i.stateNode && i.stateNode.props && i.stateNode.props.onSendMessage);
 
-    return instance && instance.stateNode.props;
+    return fiber && fiber.stateNode.props;
 }
 
 function sendWhisper(target, content) {


### PR DESCRIPTION
I noticed the report button was no longer there even though I still had the extension installed.

- Looks like Twitch has updated the version of React it uses at some point. React's more recent versions store its internal state in a property named `__reactFiber$xxxxx`, while this extension was still looking for `__reactInternalInstance$xxxxx`. 
- Tacked on an adjustment to the report button's positioning

![image](https://github.com/user-attachments/assets/2cda9946-6656-4f86-9035-1983a29769e1)


Tested on: Firefox